### PR TITLE
Insecure compare rule documentation, plus fixes

### DIFF
--- a/doc/scanner/insecureCompare.md
+++ b/doc/scanner/insecureCompare.md
@@ -1,0 +1,51 @@
+# `insecureCompare` — insecure comparison with secret data
+
+- Kind: security
+- Related CWE: [CWE-208](https://cwe.mitre.org/data/definitions/208.html)
+- Labels used: `secret`, `string.equals`
+
+## Description
+
+Ordinary string comparison of user-provided data with a piece of secret
+data can leak information about the secret through timing side channel
+because of short-circuting (returning false on first mismatch). This can
+allow the attacker to significantly speed up brute forcing, turning an
+intractable exponential problem into a linear one.
+
+## Usage
+
+When generating appmaps, ensure that string comparison functions (such as
+`String#==` in Ruby and `String.equals` in Java) are traced and correctly
+labeled with `string.equals`. Any functions you know to return a secret
+(eg. a model accessor for an API key) should be labeled `secret`.
+
+## Mitigation
+
+To fix this issue, either hash values before comparing or use a constant-time
+comparison in such operations. Constant-time comparison functions always
+compare every character of the string, removing the timing side channel.
+You can usually find functions like this in cryptographic and utility libraries, 
+eg. `ActiveSupport::SecurityUtils.secure_compare`.
+
+## Operation
+
+The rule looks for events labeled `secret` and `string.equals`.
+
+On encountering an event labeled `secret` it remembers the return value.
+
+On encountering `string.equals` it looks at the arguments and the receiver.
+If any of the arguments is a previously seen secret or looks like a secret key
+of some kind (ie. matches a regex from `src/analyzer/secretsRegexesData.json`)
+the comparison is flagged as insecure, unless any of the arguments is a
+BCrypt digest.
+
+## Known issues
+
+Since using this rule generally requires labeling all string comparisons its use
+is currently limited due to performance and space overhead of tracing them:
+string comparisons are commonly used throughout the code base and libraries.
+
+It's advisable to only trace string equality on a limited subset of tests 
+(perhaps the ones known to touch secret related functionality); alas, this is not 
+something easily attainable with current AppMap recorders and requires
+swapping or modifying configuration files.

--- a/src/analyzer/secretsRegexes.ts
+++ b/src/analyzer/secretsRegexes.ts
@@ -14,4 +14,9 @@ const REGEXES: { [key: string]: RegExp[] } = Object.keys(regexData).reduce((memo
   return memo;
 }, {} as { [key: string]: RegExp[] });
 
+const AnySecretRE = new RegExp('(?:' + Object.values(regexData).flat().join(')|(?:') + ')');
+
+// Check if a string contains any defined secret regex
+export const looksSecret = AnySecretRE.test.bind(AnySecretRE);
+
 export default REGEXES;

--- a/src/rules/insecureCompare.ts
+++ b/src/rules/insecureCompare.ts
@@ -1,6 +1,6 @@
 import { Event } from '@appland/models';
 import recordSecrets from '../analyzer/recordSecrets';
-import SecretsRegexes from '../analyzer/secretsRegexes';
+import { looksSecret } from '../analyzer/secretsRegexes';
 import { Rule, RuleLogic } from '../types.d';
 
 const BCRYPT_REGEXP = /^[$]2[abxy]?[$](?:0[4-9]|[12][0-9]|3[01])[$][./0-9a-zA-Z]{53}$/;
@@ -19,10 +19,7 @@ function stringEquals(e: Event): boolean {
   }
 
   function isSecret(str: string): boolean {
-    if (secrets.has(str)) {
-      return true;
-    }
-    return Object.values(SecretsRegexes).some((res) => res.some((re) => re.test(str)));
+    return secrets.has(str) || looksSecret(str);
   }
 
   // BCrypted strings are safe to compare using equals()

--- a/src/rules/insecureCompare.ts
+++ b/src/rules/insecureCompare.ts
@@ -28,14 +28,7 @@ function stringEquals(e: Event): string | boolean | import('../types').MatchResu
   }
 
   // BCrypted strings are safe to compare using equals()
-  if (args.every(isBcrypt)) {
-    return;
-  }
-  if (!args.every(isSecret)) {
-    return;
-  }
-
-  return true;
+  return args.some(isSecret) && !args.some(isBcrypt);
 }
 
 function build(): RuleLogic {

--- a/src/rules/insecureCompare.ts
+++ b/src/rules/insecureCompare.ts
@@ -7,12 +7,12 @@ const BCRYPT_REGEXP = /^[$]2[abxy]?[$](?:0[4-9]|[12][0-9]|3[01])[$][./0-9a-zA-Z]
 
 const secrets: Set<string> = new Set();
 
-function stringEquals(e: Event): string | boolean | import('../types').MatchResult[] | undefined {
+function stringEquals(e: Event): boolean {
   if (!e.parameters || !e.receiver || e.parameters!.length !== 1) {
-    return;
+    return false;
   }
 
-  const args = [e.receiver!.value, e.parameters![0].value];
+  const args = [e.receiver.value, e.parameters[0].value];
 
   function isBcrypt(str: string): boolean {
     return BCRYPT_REGEXP.test(str);
@@ -22,9 +22,7 @@ function stringEquals(e: Event): string | boolean | import('../types').MatchResu
     if (secrets.has(str)) {
       return true;
     }
-    return !!Object.keys(SecretsRegexes).find(
-      (key): boolean => !!SecretsRegexes[key].find((re: RegExp): boolean => re.test(str))
-    );
+    return Object.values(SecretsRegexes).some((res) => res.some((re) => re.test(str)));
   }
 
   // BCrypted strings are safe to compare using equals()
@@ -36,7 +34,7 @@ function build(): RuleLogic {
     if (e.codeObject.labels.has(Secret)) {
       recordSecrets(secrets, e);
     }
-    if (e.parameters && e.codeObject.labels.has(StringEquals)) {
+    if (e.codeObject.labels.has(StringEquals)) {
       return stringEquals(e);
     }
   }


### PR DESCRIPTION
In addition to adding the documentation, this PR also:
- fixes a logic bug in the rule,
- refactors the code,
- significantly improves performance of this rule and *secretsInLog*.

I recommend reviewing per-commit.

Fixes #69.