### PR TITLE
fix: Upload the entire findings JSON

### DIFF
--- a/src/integration/appland/upload.ts
+++ b/src/integration/appland/upload.ts
@@ -43,7 +43,10 @@ export default async function (scanResults: ScanResults, appId: string): Promise
     );
   }
 
-  tarStream.entry({ name: 'app.scanner.json' }, JSON.stringify({ findings: clonedFindings }));
+  tarStream.entry(
+    { name: 'app.scanner.json' },
+    JSON.stringify({ ...scanResults, ...{ findings: clonedFindings } })
+  );
   tarStream.finalize();
 
   const gzip = createGzip();


### PR DESCRIPTION
Previously, only the `findings` property was being sent. Now we'll send the entire scan results structure, while still overwriting the findings with our own transformed copy.

This means `appmap-server` will now have access to `summary`, `configuration`, etc.