### PR TITLE
fix: Only process a couple appmaps at a time

### DIFF
--- a/src/cli/scan.ts
+++ b/src/cli/scan.ts
@@ -12,34 +12,41 @@ type Result = {
   findings: Finding[];
 };
 
+async function batch<T>(
+  items: readonly T[],
+  size: number,
+  process: (item: T) => PromiseLike<null | undefined>
+) {
+  const left = [...items];
+  while (left.length) await Promise.all(left.splice(0, size).map(process));
+}
+
 export default async function scan(files: string[], checks: Check[]): Promise<Result> {
   const checker = new RuleChecker();
   const appMapMetadata: Record<string, Metadata> = {};
   const findings: Finding[] = [];
 
-  await Promise.all(
-    files.map(async (file: string) => {
-      // TODO: Improve this by respecting .gitignore, or similar.
-      // For now, this addresses the main problem of encountering appmap-js and its appmap.json files
-      // in a bundled node_modules.
-      if (file.split('/').includes('node_modules')) {
-        return null;
-      }
-      const appMapData = await readFile(file, 'utf8');
-      const appMap = buildAppMap(appMapData).normalize().build();
-      appMapMetadata[file] = appMap.metadata;
+  await batch(files, 2, async (file: string) => {
+    // TODO: Improve this by respecting .gitignore, or similar.
+    // For now, this addresses the main problem of encountering appmap-js and its appmap.json files
+    // in a bundled node_modules.
+    if (file.split('/').includes('node_modules')) {
+      return null;
+    }
+    const appMapData = await readFile(file, 'utf8');
+    const appMap = buildAppMap(appMapData).normalize().build();
+    appMapMetadata[file] = appMap.metadata;
 
-      await Promise.all(
-        checks.map(async (check) => {
-          const matchCount = findings.length;
-          await checker.check(file, appMap, check, findings);
-          const newMatches = findings.slice(matchCount, findings.length);
-          newMatches.forEach((match) => (match.appMapFile = file));
-          process.stderr.write(progressReporter(newMatches));
-        })
-      );
-    })
-  );
+    await Promise.all(
+      checks.map(async (check) => {
+        const matchCount = findings.length;
+        await checker.check(file, appMap, check, findings);
+        const newMatches = findings.slice(matchCount, findings.length);
+        newMatches.forEach((match) => (match.appMapFile = file));
+        process.stderr.write(progressReporter(newMatches));
+      })
+    );
+  });
 
   return { appMapMetadata, findings };
 }


### PR DESCRIPTION
Previously the scan command tried to open all the appmaps found at the same time. This not only hurt performance but could also lead to a hard error due to exhaustion of available file descriptors.

I originally hit it while trying to process all of saleor's thousands of appmaps.