### PR TITLE
feat: Rule: deserialization of untrusted data

### DIFF
--- a/doc/labels/deserialize.safe.md
+++ b/doc/labels/deserialize.safe.md
@@ -1,0 +1,9 @@
+---
+name: deserialize.safe
+rules:
+  - deserialization-of-untrusted-data
+---
+
+## Examples
+
+- Ruby [JSON.parse](https://ruby-doc.org/stdlib-3.0.2/libdoc/json/rdoc/JSON.html#method-i-parse)

--- a/doc/labels/deserialize.unsafe.md
+++ b/doc/labels/deserialize.unsafe.md
@@ -2,7 +2,9 @@
 name: deserialize.unsafe
 rules:
   - deserialization-of-untrusted-data
----## Examples
+---
+
+## Examples
 
 - Ruby [YAML.unsafe_load](https://docs.ruby-lang.org/en/3.0/Psych.html#method-c-unsafe_load)
 - Ruby [Marshal.load](https://docs.ruby-lang.org/en/3.0/Marshal.html#method-c-load)

--- a/doc/rules/deserializationOfUntrustedData.md
+++ b/doc/rules/deserializationOfUntrustedData.md
@@ -8,6 +8,7 @@ references:
 impactDomain: Security
 labels:
   - deserialize.unsafe
+  - deserialize.safe
   - sanitize
 ---
 
@@ -16,8 +17,8 @@ data is not known to be trusted.
 
 ### Rule logic
 
-Finds all events labeled `deserialize.unsafe`. For each of these events, all event parameters are
-checked.
+Finds all events labeled `deserialize.unsafe`, that are not a descendant of an event labeled
+`deserialize.safe`. For each of these events, all event parameters are checked.
 
 Each parameter whose type is `string` or `object` is verified to ensure that it's trusted. For data
 to be trusted, it must be the return value of a function labeled `sanitize`.
@@ -28,6 +29,10 @@ With insecure deserialization, it is usually possible for an attacker to craft a
 that executes code shortly after deserialization.
 
 ### Resolution
+
+If you can guarantee that you are using unsafe deserialization in a safe way, but it's not possible
+to obtain the raw data from a function labeled `sanitize`, you can wrap the deserialization in a
+function labeled `deserialize.safe`.
 
 If you need to deserialize untrusted data, JSON is often a good choice as it is only capable of
 returning ‘primitive’ types such as strings, arrays, hashes, numbers and nil. If you need to

--- a/src/rules/deserializationOfUntrustedData.ts
+++ b/src/rules/deserializationOfUntrustedData.ts
@@ -36,7 +36,10 @@ function allArgumentsSanitized(rootEvent: Event, event: Event): boolean {
 function build(): RuleLogic {
   function matcher(rootEvent: Event): MatchResult[] | undefined {
     for (const event of new EventNavigator(rootEvent).descendants()) {
-      if (event.event.labels.has(DeserializeUnsafe)) {
+      if (
+        event.event.labels.has(DeserializeUnsafe) &&
+        !event.event.ancestors().find((ancestor) => ancestor.labels.has(DeserializeSafe))
+      ) {
         if (allArgumentsSanitized(rootEvent, event.event)) {
           return;
         } else {
@@ -58,12 +61,13 @@ function build(): RuleLogic {
 }
 
 const DeserializeUnsafe = 'deserialize.unsafe';
+const DeserializeSafe = 'deserialize.safe';
 const Sanitize = 'sanitize';
 
 export default {
   id: 'deserialization-of-untrusted-data',
   title: 'Deserialization of untrusted data',
-  labels: [DeserializeUnsafe, Sanitize],
+  labels: [DeserializeUnsafe, DeserializeSafe, Sanitize],
   impactDomain: 'Security',
   enumerateScope: false,
   references: {

--- a/test/fixtures/appmaps/deserializationOfUntrustedData/Users_index_index_as_non-admin.appmap.json
+++ b/test/fixtures/appmaps/deserializationOfUntrustedData/Users_index_index_as_non-admin.appmap.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:153cb2058cf6aa48346d01bdd3f44fa6f4f0066f05f7e7282c08fb1c02ff9a37
+size 315683

--- a/test/scanner/deserializationOfUntrustedData.spec.ts
+++ b/test/scanner/deserializationOfUntrustedData.spec.ts
@@ -1,0 +1,15 @@
+import Check from '../../src/check';
+import rule from '../../src/rules/deserializationOfUntrustedData';
+import { scan } from '../util';
+
+test('unsafe deserialization', async () => {
+  const check = new Check(rule);
+  const findings = await scan(
+    check,
+    'appmaps/deserializationOfUntrustedData/Users_index_index_as_non-admin.appmap.json'
+  );
+  expect(findings).toHaveLength(1);
+  expect(findings[0].event.codeObject.fqid).toEqual(
+    'function:marshal/ActiveSupport::MarshalWithAutoloading.load'
+  );
+});


### PR DESCRIPTION
```yaml
rule: deserialization-of-untrusted-data
name: Deserialization of untrusted data
title: Deserialization of untrusted data
references:
  CWE-502: https://cwe.mitre.org/data/definitions/502.html
  Ruby Security: https://docs.ruby-lang.org/en/3.0/doc/security_rdoc.html
impactDomain: Security
labels:
  - deserialize.unsafe
  - deserialize.safe
  - sanitize
```

Finds occurrances of deserialization in which the mechanism employed is known to be unsafe, and the
data is not known to be trusted.

### Rule logic

Finds all events labeled `deserialize.unsafe`, that are not a descendant of an event labeled
`deserialize.safe`. For each of these events, all event parameters are checked.

Each parameter whose type is `string` or `object` is verified to ensure that it's trusted. For data
to be trusted, it must be the return value of a function labeled `sanitize`.

### Notes

With insecure deserialization, it is usually possible for an attacker to craft a malicious payload
that executes code shortly after deserialization.

### Resolution

If you can guarantee that you are using unsafe deserialization in a safe way, but it's not possible
to obtain the raw data from a function labeled `sanitize`, you can wrap the deserialization in a
function labeled `deserialize.safe`.

If you need to deserialize untrusted data, JSON is often a good choice as it is only capable of
returning ‘primitive’ types such as strings, arrays, hashes, numbers and nil. If you need to
deserialize other classes, you should handle this manually. Never deserialize to a user specified
class¹.

Ensure that the JSON library provided by your language and framework does not perform unsafe
deserialization.

1. https://docs.ruby-lang.org/en/3.0/doc/security_rdoc.html

### Options

None

### Examples

```yaml
- rule: deserializationOfUntrustedData
```

