### PR TITLE
Deduplicate findings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-*.appmap.json filter=lfs diff=lfs merge=lfs -text
-*.openapiv3.yaml filter=lfs diff=lfs merge=lfs -text
+*.appmap.json filter=lfs diff=lfs merge=lfs -text binary
+*.openapiv3.yaml filter=lfs diff=lfs merge=lfs -text binary
+/.yarn/releases/** binary
+/.yarn/plugins/** binary

--- a/src/report/scanResults.ts
+++ b/src/report/scanResults.ts
@@ -66,18 +66,12 @@ function collectMetadata(metadata: Metadata[]): AppMapMetadata {
  */
 export class ScanResults {
   public summary: ScanSummary;
-  public configuration: Configuration;
-  public appMaps: Record<string, Metadata>;
-  public findings: Finding[];
-
-  appMapMetadata: Record<string, Metadata>;
-  checks: Check[];
 
   constructor(
-    configuration: Configuration,
-    appMapMetadata: Record<string, Metadata>,
-    findings: Finding[],
-    checks: Check[]
+    public configuration: Configuration,
+    public appMapMetadata: Record<string, Metadata>,
+    public findings: Finding[],
+    public checks: Check[]
   ) {
     this.summary = {
       numAppMaps: Object.keys(appMapMetadata).length,
@@ -87,16 +81,6 @@ export class ScanResults {
       numFindings: findings.length,
       appMapMetadata: collectMetadata(Object.values(appMapMetadata)),
     };
-    this.configuration = configuration;
-    const appMapFiles = new Set(findings.map((finding) => finding.appMapFile));
-    this.appMaps = [...appMapFiles].reduce((memo, appMapFile) => {
-      memo[appMapFile] = appMapMetadata[appMapFile];
-      return memo;
-    }, {} as Record<string, Metadata>);
-    this.findings = findings;
-
-    this.appMapMetadata = appMapMetadata;
-    this.checks = checks;
   }
 
   withFindings(findings: Finding[]): ScanResults {

--- a/test/cli/scan.spec.ts
+++ b/test/cli/scan.spec.ts
@@ -57,7 +57,6 @@ describe('scan', () => {
     );
     expect(Object.keys(scanResults).sort()).toEqual([
       'appMapMetadata',
-      'appMaps',
       'checks',
       'configuration',
       'findings',


### PR DESCRIPTION
Also, deduplicate metadata.

I suggest reviewing commit-by-commit. Finding hashes are currently unchanged and there's more to be shaved off, but this still manages to cut down the upload size significantly. (For example with my saleor dataset it reduces 13605 total findings to 129.)