### PR TITLE
fix: Finding hash now includes rule id

### DIFF
--- a/src/ruleChecker.ts
+++ b/src/ruleChecker.ts
@@ -10,6 +10,7 @@ import HTTPClientRequestScope from './scope/httpClientRequestScope';
 import CommandScope from './scope/commandScope';
 import SQLTransactionScope from './scope/sqlTransactionScope';
 import CheckInstance from './checkInstance';
+import { createHash } from 'crypto';
 
 export default class RuleChecker {
   private scopes: Record<string, ScopeIterator> = {
@@ -111,13 +112,18 @@ export default class RuleChecker {
         findingEvent.codeObject.location,
         ...findingEvent.ancestors().map((ancestor) => ancestor.codeObject.location),
       ].filter(Boolean);
+
+      const hash = createHash('sha256');
+      hash.update(findingEvent.hash);
+      hash.update(checkInstance.ruleId);
+
       return {
         appMapFile,
         checkId: checkInstance.checkId,
         ruleId: checkInstance.ruleId,
         ruleTitle: checkInstance.title,
         event: findingEvent,
-        hash: findingEvent.hash,
+        hash: hash.digest('hex'),
         stack,
         scope,
         message: message || checkInstance.title,

--- a/test/scanner/slowHttpServerRequest.spec.ts
+++ b/test/scanner/slowHttpServerRequest.spec.ts
@@ -15,5 +15,5 @@ it('slow HTTP server request', async () => {
   expect(finding.event.id).toEqual(411);
   expect(finding.ruleTitle).toEqual('Slow HTTP server request');
   expect(finding.message).toEqual('Slow HTTP server request (> 500ms)');
-  expect(finding.hash).toEqual('a96c5258fc9f590493abcc9342c368e5b2262e95b7d38deded1dcbf97a2126d0');
+  expect(finding.hash).toEqual('c34836c5dc38a527f7a6d6c4867d60e7c8af09a3498735bb83746157d456b8a2');
 });


### PR DESCRIPTION
Previously finding hashes were just the hash of the event, so different findings on the same event were incorrectly collapsed.