### PR TITLE
fix: Prevent ENOENT when upload AppMaps

### DIFF
--- a/src/cli/ci/command.ts
+++ b/src/cli/ci/command.ts
@@ -78,10 +78,8 @@ export default {
 
       const scanner = buildScanner(false, configData, files);
 
-      const [rawScanResults, findingStatuses] = await Promise.all<
-        ScanResults,
-        FindingStatusListItem[]
-      >([scanner.scan(), scanner.fetchFindingStatus(appIdArg, appmapDir)]);
+      const [rawScanResults, findingStatuses]: [ScanResults, FindingStatusListItem[]] =
+        await Promise.all([scanner.scan(), scanner.fetchFindingStatus(appIdArg, appmapDir)]);
 
       // Always report the raw data
       await writeFile(reportFile, JSON.stringify(rawScanResults, null, 2));

--- a/src/cli/ci/command.ts
+++ b/src/cli/ci/command.ts
@@ -94,7 +94,7 @@ export default {
       summaryReport(scanResults, true);
 
       if (doUpload) {
-        await upload(rawScanResults, appId, appmapDir);
+        await upload(rawScanResults, appId);
       }
 
       if (updateCommitStatus) {

--- a/src/cli/upload/command.ts
+++ b/src/cli/upload/command.ts
@@ -44,6 +44,6 @@ export default {
     const appId = await resolveAppId(appIdArg, appmapDir);
 
     const scanResults = JSON.parse((await readFile(reportFile)).toString()) as ScanResults;
-    await upload(scanResults, appId, appmapDir);
+    await upload(scanResults, appId);
   },
 };

--- a/src/integration/appland/upload.ts
+++ b/src/integration/appland/upload.ts
@@ -8,14 +8,9 @@ import { buildRequest, handleError } from '@appland/client/dist/src';
 import { ScanResults } from '../../report/scanResults';
 import { AppMap as AppMapClient, UploadAppMapResponse } from './appMap';
 import { Mapset as MapsetClient } from './mapset';
-import { join } from 'path';
 import { readFile } from 'fs/promises';
 
-export default async function (
-  scanResults: ScanResults,
-  appId: string,
-  appmapDir: string
-): Promise<URL> {
+export default async function (scanResults: ScanResults, appId: string): Promise<URL> {
   console.warn(`Uploading AppMaps and findings to application '${appId}'`);
 
   const { findings } = scanResults;
@@ -31,7 +26,7 @@ export default async function (
   const q = queue((filePath: string, callback) => {
     console.log(`Uploading AppMap ${filePath}`);
 
-    readFile(join(appmapDir, filePath))
+    readFile(filePath)
       .then((buffer: Buffer) => {
         const appMapStruct = JSON.parse(buffer.toString()) as AppMapStruct;
         const branch = appMapStruct.metadata.git?.branch;


### PR DESCRIPTION
This should fix the following issue:
```
$ npx @appland/scanner ci -d tmp/appmap
[...]
Uploading AppMap tmp/appmap/rspec/API_Keys_user_page_allows_the_user_to_create_a_new_api_key.appmap.json
An error occurred uploading  tmp/appmap/rspec/API_Keys_user_page_allows_the_user_to_create_a_new_api_key.appmap.json: Error: ENOENT: no such file or directory, open 'tmp/appmap/ tmp/appmap/rspec/API_Keys_user_page_allows_the_user_to_create_a_new_api_key.appmap.json'
```

My understanding is that the value of `appMapDir` is appended to the finding's `appMapFile` path prior to uploading, so joining the two would result in an invalid path. I'm not 100% sure if this is always the case however.