### PR TITLE
fix: Prevent accumulation of AppMap data while scanning

### DIFF
--- a/src/eventUtil.ts
+++ b/src/eventUtil.ts
@@ -1,0 +1,50 @@
+import { CodeObject, Event } from '@appland/models';
+
+// TODO: These interfaces can be removed once @appland/models is up to date.
+interface EventConstructor {
+  new (data: unknown): Event;
+}
+
+interface CodeObjectConstructor {
+  new (data: unknown, parent?: CodeObject): CodeObject;
+}
+
+export function cloneCodeObject(sourceObject: CodeObject): CodeObject | undefined {
+  const codeObjects = [
+    sourceObject,
+    ...(sourceObject.ancestors as unknown as () => CodeObject[])(),
+  ];
+  let currentSourceObject = codeObjects.pop();
+  let lastClonedObject;
+
+  while (currentSourceObject) {
+    lastClonedObject = new (CodeObject as CodeObjectConstructor)(
+      (currentSourceObject as unknown as { data: unknown }).data,
+      lastClonedObject
+    );
+    currentSourceObject = codeObjects.pop();
+  }
+
+  return lastClonedObject;
+}
+
+// FIXME: These methods should live in @appland/models. Perhaps via Event#clone.
+
+export function cloneEvent(sourceEvent: Event): Event {
+  // We need to clone both the sourceEvent and the 'linkedEvent'. The linkedEvent will be a return
+  // if `sourceEvent` is a call and vice versa. Some accessors on the Event will use the linkedEvent
+  // as a convienence, so we may run into errors if we don't restore this relationship. For example,
+  // accessing `elapsedTime` on a call event will retrieve the value from the associated return
+  // event.
+  const linkedEvent = new (Event as EventConstructor)(sourceEvent.linkedEvent);
+  const event = new (Event as EventConstructor)(sourceEvent);
+  event.linkedEvent = linkedEvent;
+
+  // The codeObject is used as well so it'll need a clone.
+  const codeObject = cloneCodeObject(sourceEvent.codeObject);
+  if (codeObject) {
+    event.codeObject = codeObject;
+  }
+
+  return event;
+}

--- a/src/ruleChecker.ts
+++ b/src/ruleChecker.ts
@@ -11,6 +11,7 @@ import CommandScope from './scope/commandScope';
 import SQLTransactionScope from './scope/sqlTransactionScope';
 import CheckInstance from './checkInstance';
 import { createHash } from 'crypto';
+import { cloneEvent } from './eventUtil';
 
 export default class RuleChecker {
   private scopes: Record<string, ScopeIterator> = {
@@ -122,14 +123,14 @@ export default class RuleChecker {
         checkId: checkInstance.checkId,
         ruleId: checkInstance.ruleId,
         ruleTitle: checkInstance.title,
-        event: findingEvent,
+        event: cloneEvent(findingEvent),
         hash: hash.digest('hex'),
         stack,
-        scope,
+        scope: cloneEvent(scope),
         message: message || checkInstance.title,
         groupMessage,
         occurranceCount,
-        relatedEvents,
+        relatedEvents: relatedEvents?.map((event) => cloneEvent(event)),
       } as Finding;
     };
 

--- a/test/eventUtil.spec.ts
+++ b/test/eventUtil.spec.ts
@@ -1,0 +1,38 @@
+import { CodeObject, Event } from '@appland/models';
+import { cloneEvent, cloneCodeObject } from '../src/eventUtil';
+import { fixtureAppMap } from './util';
+
+describe('eventUtil', () => {
+  describe('cloneEvent', () => {
+    it('provides access to expected values', async () => {
+      const appmap = await fixtureAppMap(
+        'org_springframework_samples_petclinic_owner_OwnerControllerTests_testInitCreationForm.appmap.json'
+      );
+      const expected = appmap.events.find((e) => e.isCall()) as Event;
+      const subject = cloneEvent(expected);
+
+      expect(subject.id).toEqual(expected.id);
+      expect(subject.definedClass).toEqual(expected.definedClass);
+      expect(subject.codeObject.fqid).toEqual(expected.codeObject.fqid);
+      expect(subject.linkedEvent.id).toEqual(expected.linkedEvent.id);
+      expect(subject.ancestors()).toEqual([]);
+      expect(subject.descendants()).toEqual([]);
+      expect(JSON.stringify(subject)).toEqual(JSON.stringify(expected));
+    });
+  });
+
+  describe('cloneCodeObject', () => {
+    it('provides access to expected values', async () => {
+      const appmap = await fixtureAppMap(
+        'org_springframework_samples_petclinic_owner_OwnerControllerTests_testInitCreationForm.appmap.json'
+      );
+      const expected = appmap.events.find((e) => e.isCall())?.codeObject as CodeObject;
+      const subject = cloneCodeObject(expected) as CodeObject;
+
+      expect(subject.fqid).toEqual(expected.fqid);
+      expect(subject.parent).toBeDefined();
+      expect(subject.parent?.id).toEqual(expected.parent?.id);
+      expect(JSON.stringify(subject)).toEqual(JSON.stringify(expected));
+    });
+  });
+});


### PR DESCRIPTION
Previously, event references in findings would cause entire AppMaps to stay loaded into memory. With this change we now create a shallow copy of Event objects to break these references.

I was able to confirm that the memory usage no longer grows dramatically with each AppMap scanned via the [node inspector built into Chrome](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients). In my local testing, total heap size drops from ~250MB to ~35MB after a full `ci` run.