### PR TITLE
fix: Provide the `metadata` param during AppMap creation

### DIFF
--- a/src/integration/appland/appMap/create.ts
+++ b/src/integration/appland/appMap/create.ts
@@ -2,6 +2,7 @@ import { IncomingMessage } from 'http';
 
 import { buildRequest, handleError } from '@appland/client/dist/src';
 import FormData from 'form-data';
+import { Metadata } from '@appland/models';
 
 export type UploadAppMapResponse = {
   uuid: string;
@@ -9,6 +10,7 @@ export type UploadAppMapResponse = {
 
 export type CreateOptions = {
   app?: string;
+  metadata?: Metadata;
 };
 
 export async function create(
@@ -17,6 +19,9 @@ export async function create(
 ): Promise<UploadAppMapResponse> {
   const form = new FormData();
   form.append('data', data.toString());
+  if (options.metadata) {
+    form.append('metadata', JSON.stringify(options.metadata));
+  }
   if (options.app) {
     form.append('app', options.app);
   }

--- a/src/integration/appland/scannerJob/create.ts
+++ b/src/integration/appland/scannerJob/create.ts
@@ -53,6 +53,7 @@ export async function create(
     readFile(filePath)
       .then((buffer: Buffer) => {
         const appMapStruct = JSON.parse(buffer.toString()) as AppMapStruct;
+        const metadata = appMapStruct.metadata;
         const branch = appMapStruct.metadata.git?.branch;
         const commit = appMapStruct.metadata.git?.commit;
         if (branch) {
@@ -64,7 +65,7 @@ export async function create(
           commitCount[commit] += 1;
         }
 
-        return createAppMap(buffer, createAppMapOptions);
+        return createAppMap(buffer, { ...createAppMapOptions, metadata });
       })
       .then((appMap: UploadAppMapResponse) => {
         if (appMap) {

--- a/test/integration/appMap.create.spec.ts
+++ b/test/integration/appMap.create.spec.ts
@@ -1,30 +1,60 @@
-import nock from 'nock';
+import nock, { RequestBodyMatcher } from 'nock';
 
 import * as test from './setup';
 import { create, CreateOptions } from '../../src/integration/appland/appMap/create';
+import { Metadata } from '@appland/models';
 
 const AppMapData = {
   uuid: 'the-uuid',
 };
 
+interface TestOptions {
+  data?: Buffer;
+  app?: string;
+  metadata?: Metadata;
+  requestBodyHandler?: (body: RequestBodyMatcher) => boolean;
+}
+
+async function createAppMap(options: TestOptions): Promise<void> {
+  const data = options.data || Buffer.from(JSON.stringify({}));
+  const createOptions = {
+    app: options.app || test.AppId,
+    metadata: options.metadata,
+  };
+
+  nock('http://localhost:3000')
+    .post(`/api/appmaps`, options.requestBodyHandler)
+    .matchHeader(
+      'Authorization',
+      'Bearer a2dpbHBpbkBnbWFpbC5jb206NzU4Y2NmYTYtNjYwNS00N2Y0LTgxYWUtNTg2MmEyY2M0ZjY5'
+    )
+    .matchHeader('Content-Type', /^multipart\/form-data; boundary/)
+    .matchHeader('Accept', /^application\/json;?/)
+    .reply(201, AppMapData, ['Content-Type', 'application/json']);
+  expect(await create(data, createOptions)).toEqual(AppMapData);
+}
+
 describe('appMap', () => {
   describe('create', () => {
     it('succeeds', async () => {
-      const data = Buffer.from(JSON.stringify({}));
-      const options = {
-        app: test.AppId,
-      } as CreateOptions;
+      await createAppMap({
+        metadata: { name: 'example' } as Metadata,
+        requestBodyHandler(body: RequestBodyMatcher) {
+          expect(body).toMatch(/Content-Disposition: form-data; name="data"/);
+          expect(body).toMatch(/Content-Disposition: form-data; name="metadata"/);
+          return true;
+        },
+      });
+    });
 
-      nock('http://localhost:3000')
-        .post(`/api/appmaps`, /Content-Disposition: form-data/)
-        .matchHeader(
-          'Authorization',
-          'Bearer a2dpbHBpbkBnbWFpbC5jb206NzU4Y2NmYTYtNjYwNS00N2Y0LTgxYWUtNTg2MmEyY2M0ZjY5'
-        )
-        .matchHeader('Content-Type', /^multipart\/form-data; boundary/)
-        .matchHeader('Accept', /^application\/json;?/)
-        .reply(201, AppMapData, ['Content-Type', 'application/json']);
-      expect(await create(data, options)).toEqual(AppMapData);
+    it('succeeds with null metadata', async () => {
+      await createAppMap({
+        requestBodyHandler(body: RequestBodyMatcher) {
+          expect(body).toMatch(/Content-Disposition: form-data; name="data"/);
+          expect(body).not.toMatch(/Content-Disposition: form-data; name="metadata"/);
+          return true;
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
Resolves SCAN-129

This allows the metadata to be written immediately before processing AppMap data. The server allows this parameter to be supplied separately to prevent the overhead of a full JSON deserialization. 