### PR TITLE
fix: Better error message if AppLand server is not configured

### DIFF
--- a/src/cli/ci/command.ts
+++ b/src/cli/ci/command.ts
@@ -82,7 +82,7 @@ export default {
 
       const configData = await parseConfigFile(config);
 
-      const scanner = buildScanner(false, configData, files);
+      const scanner = await buildScanner(false, configData, files);
 
       const [rawScanResults, findingStatuses]: [ScanResults, FindingStatusListItem[]] =
         await Promise.all([scanner.scan(), scanner.fetchFindingStatus(appIdArg, appmapDir)]);

--- a/src/cli/scan/command.ts
+++ b/src/cli/scan/command.ts
@@ -86,7 +86,11 @@ export default {
 
       const configData = await parseConfigFile(config);
 
-      const scanner = buildScanner(reportAllFindings, configData, files);
+      const scanner = await buildScanner(reportAllFindings, configData, files).catch(
+        (error: Error) => {
+          throw new ValidationError(error.message + '\nUse --all to perform an offline scan.');
+        }
+      );
 
       const startTime = Date.now();
 

--- a/src/cli/scan/scanner.ts
+++ b/src/cli/scan/scanner.ts
@@ -8,53 +8,36 @@ import resolveAppId from '../resolveAppId';
 import scan from '../scan';
 import { ScanResults } from '../../report/scanResults';
 
-interface Scanner {
+export interface Scanner {
   scan(): Promise<ScanResults>;
 
   fetchFindingStatus(appId?: string, appMapDir?: string): Promise<FindingStatusListItem[]>;
 }
 
-export default function scanner(
+export default async function scanner(
   reportAllFindings: boolean,
   configuration: Configuration,
   files: string[]
-): Scanner {
-  return reportAllFindings
-    ? new StandaloneScanner(configuration, files)
-    : new ServerIntegratedScanner(configuration, files);
+): Promise<Scanner> {
+  if (reportAllFindings) {
+    return new StandaloneScanner(configuration, files);
+  } else {
+    await loadConfiguration();
+    return new ServerIntegratedScanner(configuration, files);
+  }
 }
 
 abstract class ScannerBase {
   constructor(public configuration: Configuration, public files: string[]) {}
 
   async scan(): Promise<ScanResults> {
-    await this.verifyServerConfiguration();
-
     const checks = await loadConfig(this.configuration);
     const { appMapMetadata, findings } = await scan(this.files, checks);
     return new ScanResults(this.configuration, appMapMetadata, findings, checks);
   }
-
-  protected abstract verifyServerConfiguration(): Promise<boolean>;
 }
 
 class ServerIntegratedScanner extends ScannerBase implements Scanner {
-  async verifyServerConfiguration(): Promise<boolean> {
-    return new Promise((resolve) => {
-      loadConfiguration()
-        .then(() => resolve(true))
-        .catch((err) => {
-          console.warn(`⚠️ Notice ⚠️`);
-          console.warn(`⚠️ AppMap Server configuration is not available.`);
-          console.warn(`⚠️ Detailed message: ${err.toString()}`);
-          console.warn(
-            `⚠️ Scanning will continue without fetching existing findings from the server.`
-          );
-          resolve(false);
-        });
-    });
-  }
-
   async fetchFindingStatus(
     appIdArg?: string,
     appMapDir?: string


### PR DESCRIPTION
In cases where eg. API key is not configured, the message said that
online features would be skipped, but then the scan failed anyway.
New message correctly says to use `--all` to proceed offline.