### PR TITLE
feat: Additional related events

### DIFF
--- a/src/ruleChecker.ts
+++ b/src/ruleChecker.ts
@@ -129,15 +129,13 @@ export default class RuleChecker {
 
       const uniqueEvents = new Set<number>();
       const relatedEvents: Array<Event> = [];
-      [cloneEvent(findingEvent)]
-        .concat((additionalEvents || []).map((event) => cloneEvent(event)))
-        .forEach((event) => {
-          if (uniqueEvents.has(event.id)) {
-            return;
-          }
-          uniqueEvents.add(event.id);
-          relatedEvents.push(event);
-        });
+      [findingEvent].concat((additionalEvents || []).map(cloneEvent)).forEach((event) => {
+        if (uniqueEvents.has(event.id)) {
+          return;
+        }
+        uniqueEvents.add(event.id);
+        relatedEvents.push(event);
+      });
 
       return {
         appMapFile,

--- a/src/rules/authzBeforeAuthn.ts
+++ b/src/rules/authzBeforeAuthn.ts
@@ -26,7 +26,6 @@ function build(): RuleLogic {
         } else {
           return [
             {
-              level: 'error',
               event: event.event,
               message: `${event.event} provides authorization, but the request is not authenticated`,
             },

--- a/src/rules/deserializationOfUntrustedData.ts
+++ b/src/rules/deserializationOfUntrustedData.ts
@@ -31,7 +31,6 @@ function build(): RuleLogic {
         } else {
           return [
             {
-              level: 'error',
               event: event.event,
               message: `${event.event} deserializes untrusted data`,
             },

--- a/src/rules/execOfUntrustedCommand.ts
+++ b/src/rules/execOfUntrustedCommand.ts
@@ -30,7 +30,6 @@ function build(): RuleLogic {
         } else {
           return [
             {
-              level: 'error',
               event: event.event,
               message: `${event.event} executes an untrusted command string`,
             },

--- a/src/rules/illegalPackageDependency.ts
+++ b/src/rules/illegalPackageDependency.ts
@@ -1,6 +1,6 @@
 import { Event } from '@appland/models';
 import types from './types';
-import { MatcherResult, Rule, RuleLogic } from '../types';
+import { MatchResult, Rule, RuleLogic } from '../types';
 import MatchPatternConfig from 'src/configuration/types/matchPatternConfig';
 import { buildFilter, buildFilters } from './lib/matchPattern';
 import { URL } from 'url';
@@ -19,7 +19,7 @@ function build(options: Options): RuleLogic {
     return !!e.parent && !!e.parent!.codeObject.packageOf && calleePattern(e.codeObject.packageOf);
   }
 
-  function matcher(e: Event): MatcherResult {
+  function matcher(e: Event): MatchResult[] | undefined {
     const packageNamesStr = options.callerPackages
       .map((config) => config.equal || config.include || config.match)
       .map(String)
@@ -32,7 +32,13 @@ function build(options: Options): RuleLogic {
         callerPatterns.some((pattern) => pattern(parentPackage))
       )
     ) {
-      return `Code object ${e.codeObject.id} was invoked from ${parentPackage}, not from ${packageNamesStr}`;
+      return [
+        {
+          event: e,
+          message: `Code object ${e.codeObject.id} was invoked from ${parentPackage}, not from ${packageNamesStr}`,
+          relatedEvents: [e.parent!],
+        },
+      ];
     }
   }
 

--- a/src/rules/incompatibleHttpClientRequest.ts
+++ b/src/rules/incompatibleHttpClientRequest.ts
@@ -34,7 +34,7 @@ function build(options: Options): RuleLogic {
     } as OpenAPIV3.Document;
     const changes = await breakingChanges(clientSchema, serverSchema);
     return changes.map((change: OpenApiDiff.DiffResult<'breaking'>) => ({
-      level: 'error',
+      event,
       message: changeMessage(change),
     }));
   }

--- a/src/rules/jobNotCancelled.ts
+++ b/src/rules/jobNotCancelled.ts
@@ -21,7 +21,6 @@ function build(): RuleLogic {
     if (missing === 0) return;
 
     const result: MatchResult = {
-      level: 'error',
       event: event,
       message: `${missing} jobs created but not cancelled in this rolled back transaction`,
       // if there's a mismatch and there are cancellations we can't tell

--- a/src/rules/logoutWithoutSessionReset.ts
+++ b/src/rules/logoutWithoutSessionReset.ts
@@ -23,7 +23,6 @@ function build(): RuleLogic {
         } else {
           return [
             {
-              level: 'error',
               event: event.event,
               message: `${event.event} logs out the user, but the HTTP session is not cleared`,
             },

--- a/src/rules/queryFromInvalidPackage.ts
+++ b/src/rules/queryFromInvalidPackage.ts
@@ -1,5 +1,5 @@
 import { Event } from '@appland/models';
-import { Rule, RuleLogic } from 'src/types';
+import { MatchResult, Rule, RuleLogic } from 'src/types';
 import * as types from './types';
 import MatchPatternConfig from 'src/configuration/types/matchPatternConfig';
 import { buildFilters } from './lib/matchPattern';
@@ -20,11 +20,18 @@ function build(options: Options): RuleLogic {
   const allowedPackages = buildFilters(options.allowedPackages);
   const allowedQueries = buildFilters(options.allowedQueries);
 
-  function matcher(e: Event) {
+  function matcher(e: Event): MatchResult[] | undefined {
     if (!allowedPackages.some((filter) => filter(e.parent!.codeObject.packageOf))) {
-      return `${e.codeObject.id} is invoked from illegal package ${e.parent!.codeObject.packageOf}`;
+      return [
+        {
+          event: e,
+          message: `${e.codeObject.id} is invoked from illegal package ${
+            e.parent!.codeObject.packageOf
+          }`,
+          relatedEvents: [e.parent!],
+        },
+      ];
     }
-    return false;
   }
 
   function where(e: Event) {

--- a/src/rules/queryFromView.ts
+++ b/src/rules/queryFromView.ts
@@ -10,7 +10,18 @@ class Options implements types.QueryFromView.Options {
 
 function build(options: Options = new Options()): RuleLogic {
   function matcher(e: Event) {
-    return e.ancestors().some((e: Event) => e.codeObject.labels.has(options.forbiddenLabel));
+    const forbiddenAncestor = e
+      .ancestors()
+      .find((e: Event) => e.codeObject.labels.has(options.forbiddenLabel));
+    if (forbiddenAncestor) {
+      return [
+        {
+          event: e,
+          message: `SQL query is invoked from invalid event ${forbiddenAncestor}, labeled ${options.forbiddenLabel}`,
+          relatedEvents: [forbiddenAncestor],
+        },
+      ];
+    }
   }
   function where(e: Event) {
     return !!e.sqlQuery;

--- a/src/rules/tooManyJoins.ts
+++ b/src/rules/tooManyJoins.ts
@@ -42,7 +42,6 @@ function build(options: Options = new Options()): RuleLogic {
 
       if (occurrence.joins >= options.warningLimit) {
         matchResults.push({
-          level: 'warning',
           event: occurrence.events[0],
           message: `${occurrence.joins} join${occurrence.joins > 1 ? 's' : ''} in SQL "${sql}"`,
           relatedEvents: occurrence.events,

--- a/src/rules/tooManyUpdates.ts
+++ b/src/rules/tooManyUpdates.ts
@@ -49,7 +49,6 @@ function build(options: Options): RuleLogic {
     if (events.length > options.warningLimit) {
       return [
         {
-          level: 'error',
           message: `Command performs ${events.length} SQL and RPC updates`,
           event: events[0],
           relatedEvents: events,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -59,9 +59,9 @@ type EventFilter = (e: Event, appMapIndex: AppMapIndex) => boolean;
  * MatchResult is created by a rule when it matches an Event.
  */
 export interface MatchResult {
-  level: Level;
-  event?: Event;
-  message?: string;
+  level?: Level;
+  event: Event;
+  message: string;
   groupMessage?: string;
   occurranceCount?: number;
   relatedEvents?: Event[];


### PR DESCRIPTION
Include the match event in `relatedEvents` so that the user can always cycle through all the finding events. 

Also, add some relatedEvents to src/rules/illegalPackageDependency.ts, src/rules/queryFromInvalidPackage.ts, src/rules/queryFromView.ts
