### PR TITLE
fix: normalize git repository URLs

### DIFF
--- a/src/integration/appland/normalize.ts
+++ b/src/integration/appland/normalize.ts
@@ -1,0 +1,16 @@
+import { ScanResults } from '../../report/scanResults';
+import { Metadata } from '@appland/models';
+import { URL } from 'url';
+
+export default function normalize(results: ScanResults): ScanResults {
+  results.summary.appMapMetadata.git.map(function (metadata: Metadata.Git) {
+    if (/^https/.test(metadata.repository)) {
+      const url = new URL(metadata.repository);
+      url.username = url.password = '';
+      metadata.repository = url.toString();
+    }
+    return metadata;
+  });
+
+  return results;
+}

--- a/src/integration/appland/scannerJob/create.ts
+++ b/src/integration/appland/scannerJob/create.ts
@@ -16,6 +16,7 @@ import ScannerJob from '../scannerJob';
 import { RetryOptions } from '../retryOptions';
 import retry from '../retry';
 import { Request } from '@appland/client/dist/src/buildRequest';
+import normalize from '../normalize';
 
 type CreateOptions = {
   mergeKey?: string;
@@ -38,7 +39,7 @@ export async function create(
 
   async function makeRequest(): Promise<IncomingMessage> {
     const payload = JSON.stringify({
-      scan_results: scanResults,
+      scan_results: normalize(scanResults),
       mapset: mapsetId,
       appmap_uuid_by_file_name: appMapUUIDByFileName,
       ...{ merge_key: createOptions.mergeKey },

--- a/test/integration/appland/normalize.test.ts
+++ b/test/integration/appland/normalize.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import normalize from '../../../src/integration/appland/normalize';
+
+describe('normalize', () => {
+  const FixtureDir = 'test/fixtures/scanResults';
+  const results = JSON.parse(readFileSync(join(FixtureDir, 'scanResults.json')).toString());
+
+  it('does not change normalized HTTPS repository URLs', () => {
+    results.summary.appMapMetadata.git[0].repository =
+      'https://gitlab.com/org/repo.git';
+    const repository = normalize(results).summary.appMapMetadata.git[0].repository;
+    expect(repository).toBe('https://gitlab.com/org/repo.git');
+  });
+
+  it('does not change normalized SSH repository URLs', () => {
+    results.summary.appMapMetadata.git[0].repository =
+      'git@github.com:applandinc/appmap-server.git';
+    const repository = normalize(results).summary.appMapMetadata.git[0].repository;
+    expect(repository).toBe('git@github.com:applandinc/appmap-server.git');
+  });
+
+  it('removes username/password from HTTPS repository URLs', () => {
+    results.summary.appMapMetadata.git[0].repository =
+      'https://user-ci:token-token@gitlab.com/org/repo.git';
+    const repository = normalize(results).summary.appMapMetadata.git[0].repository;
+    expect(repository).toBe('https://gitlab.com/org/repo.git');
+  });
+});


### PR DESCRIPTION
Fixes SCAN-196

This change is needed to remove username/password from git repository URLs.